### PR TITLE
Unnecessary navigation bar buttons/links were removed

### DIFF
--- a/portal/templates/layouts/base.html
+++ b/portal/templates/layouts/base.html
@@ -38,8 +38,6 @@
           <li class="pretty_li"><a class="pretty_anchor" href="/courses">Courses</a></li>
           <li class="pretty_li"><a class="pretty_anchor" href="/sessions">Sessions</a></li>
           <li class="pretty_li"><a class="pretty_anchor" href="/assignments">Assignments</a></li>
-          <li class="pretty_li"><a class="pretty_anchor" href="placeholder">News</a></li>
-          <li class="pretty_li"><a class="pretty_anchor" href="placeholder">About</a></li>
         </ul>
       </nav>
       {% endif %}
@@ -48,8 +46,6 @@
         <ul>
           <li class="pretty_li"><a class="pretty_anchor" href="/home">Home</a></li>
           <li class="pretty_li"><a class="pretty_anchor" href="/my_courses">Courses</a></li>
-          <li class="pretty_li"><a class="pretty_anchor" href="placeholder">News</a></li>
-          <li class="pretty_li"><a class="pretty_anchor" href="placeholder">About</a></li>
         </ul>
       </nav>
       {% endif %}


### PR DESCRIPTION
Unnecessary navigation bar buttons/links were removed from both the 'teacher' and 'student' versions of the website in order to prevent
confusion.
- Buttons removed: 'News' & 'About'.